### PR TITLE
ec.refocus sets window topmost

### DIFF
--- a/expyfun/_experiment_controller.py
+++ b/expyfun/_experiment_controller.py
@@ -2176,13 +2176,10 @@ class ExperimentController(object):
             m_hWnd = self._win._hwnd
             hCurWnd = _user32.GetForegroundWindow()
             if hCurWnd != m_hWnd:
+                _user32.SetWindowPos(m_hWnd, -1, 0, 0, 0, 0, 0x0001 | 0x0002)
                 dwMyID = _user32.GetWindowThreadProcessId(m_hWnd, 0)
                 dwCurID = _user32.GetWindowThreadProcessId(hCurWnd, 0)
                 _user32.AttachThreadInput(dwCurID, dwMyID, True)
-                # _user32.SetWindowPos(m_hWnd, HWND_TOPMOST, 0, 0, 0, 0,
-                #                      SWP_NOSIZE | SWP_NOMOVE)
-                # _user32.SetWindowPos(m_hWnd, HWND_NOTOPMOST, 0, 0, 0, 0,
-                #                      SWP_NOSIZE | SWP_NOMOVE)
                 self._win.activate()  # _user32.SetForegroundWindow(m_hWnd)
                 _user32.AttachThreadInput(dwCurID, dwMyID, False)
                 _user32.SetFocus(m_hWnd)


### PR DESCRIPTION
Added a line in the experiment_contoller refocus function which should bring the experiment window to the front. Also deleted equivalent code which was commented out.